### PR TITLE
Add cross-platform support

### DIFF
--- a/FuckMake/src/parsing/parsing.cpp
+++ b/FuckMake/src/parsing/parsing.cpp
@@ -33,10 +33,10 @@ FuckMake::FuckMake(const String& filename, const String& target) {
 void FuckMake::Parse(String& string) {
 	uint64 fuckMakeStart = string.Find("!FuckMake");
 
-	if (fuckMakeStart == ~0) {
+	if (fuckMakeStart == String::npos) {
 		Log(LogLevel::Error, "Not a Fuckfile!");
 		exit(1);
-	} 
+	}
 
 	if (fuckMakeStart != 0) {
 		string.Remove(0, fuckMakeStart+9);
@@ -50,11 +50,11 @@ void FuckMake::Parse(String& string) {
 void FuckMake::ParseVariables(String& string) {
 	uint64 equalIndex = 0;
 
-	while ((equalIndex = string.Find('=')) != ~0) {
+	while ((equalIndex = string.Find('=')) != String::npos) {
 		uint64 start = string.FindReversed('\n', equalIndex) + 1;
 		uint64 end = string.Find('\n', equalIndex);
 
-		if (start == ~0 || end == ~0) {
+		if (start == String::npos || end == String::npos) {
 			Log(LogLevel::Error, "Error");
 			exit(1);
 		}
@@ -82,7 +82,7 @@ void FuckMake::ParseVariables(String& string) {
 void FuckMake::ParseActions(String& string) {
 	uint64 openBracket = 0;
 
-	while ((openBracket = string.Find('{')) != ~0) {
+	while ((openBracket = string.Find('{')) != String::npos) {
 		uint64 start = string.FindReversed('\n', openBracket)+1;
 		uint64 end = string.Find('}', openBracket);
 
@@ -104,11 +104,11 @@ void FuckMake::ParseActions(String& string) {
 void FuckMake::ParseTargets(String& string) {
 	uint64 colon = 0;
 
-	while ((colon = string.Find(':')) != ~0) {
+	while ((colon = string.Find(':')) != String::npos) {
 		uint64 start = string.FindReversed('\n', colon)+1;
 		uint64 end = string.Find(':', colon + 1);
 
-		if (end == ~0) {
+		if (end == String::npos) {
 			end = string.length - 1;
 		} else {
 			end = string.FindReversed('\n', end);
@@ -130,8 +130,8 @@ void FuckMake::ParseTargets(String& string) {
 
 void FuckMake::ProcessVariables(String& string) {
 	uint64 index = 0;
-	
-	while ((index = string.Find("%(")) != ~0) {
+
+	while ((index = string.Find("%(")) != String::npos) {
 		uint64 start = index;
 		uint64 end = string.Find(')', start);
 
@@ -151,7 +151,7 @@ void FuckMake::ProcessVariables(String& string) {
 void FuckMake::ProcessFunctions(String& string) {
 	uint64 parenthesis = 0;
 
-	while ((parenthesis = string.Find('(', parenthesis + 1)) != ~0) {
+	while ((parenthesis = string.Find('(', parenthesis + 1)) != String::npos) {
 		if (string[parenthesis - 1] == '%') continue;
 
 		uint64 start = string.FindReversedOr(" \n\r\t)(=,", parenthesis-1)+1;
@@ -183,11 +183,11 @@ void FuckMake::ProcessFunctions(String& string) {
 void FuckMake::ProcessInputOuput(String& string, const String& input, const String& output) {
 	uint64 index = 0;
 
-	while ((index = string.Find("%Input")) != ~0) {
+	while ((index = string.Find("%Input")) != String::npos) {
 		string.Insert(index, index+ 5, input);
 	}
 
-	while ((index = string.Find("%Output")) != ~0) {
+	while ((index = string.Find("%Output")) != String::npos) {
 		string.Insert(index, index + 6, output);
 	}
 }
@@ -195,7 +195,7 @@ void FuckMake::ProcessInputOuput(String& string, const String& input, const Stri
 bool FuckMake::CheckWildcardPattern(const String& source, const String& pattern) {
 	uint64 previous = pattern.Find('*');
 
-	if (previous == ~0) {
+	if (previous == String::npos) {
 		Log(LogLevel::Error, "Invalid wildcard \"%s\"", pattern.str);
 		exit(1);
 	}
@@ -227,7 +227,7 @@ bool FuckMake::CheckWildcardPattern(const String& source, const String& pattern)
 		for (uint64 i = 1; i < numAsterix; i++) {
 			String tmp = pattern.SubString(previous + 1, next - 1);
 
-			if ((offset = source.Find(tmp, offset)) == ~0) {
+			if ((offset = source.Find(tmp, offset)) == String::npos) {
 				break;
 			}
 
@@ -237,7 +237,7 @@ bool FuckMake::CheckWildcardPattern(const String& source, const String& pattern)
 			next = pattern.Find('*', previous + (i + 1 < numAsterix ? 1 : 0));
 		}
 
-		if (offset == ~0) return false;
+		if (offset == String::npos) return false;
 
 		if (next < pattern.length - 1) {
 			if (source.EndsWith(pattern.SubString(next + 1, pattern.length - 1))) {
@@ -254,7 +254,7 @@ bool FuckMake::CheckWildcardPattern(const String& source, const String& pattern)
 void FuckMake::ProcessGetFiles(String& string) {
 	uint64 firstComma = string.Find(',');
 	uint64 secondComma = string.Find(',', firstComma + 1);
-	
+
 	String directory("*");
 	String wildcard;
 	String exclusion;
@@ -340,7 +340,7 @@ void FuckMake::ProcessExecuteList(String& string) {
 
 	file = string.SubString(firstComma + 1, secondComma - 1);
 	outdir = string.SubString(secondComma + 1, string.length - 1).RemoveWhitespace(true);
-	
+
 	if (!action) {
 		Log(LogLevel::Error, "No action named \"%s\"", a.str);
 		exit(1);
@@ -362,7 +362,7 @@ void FuckMake::ProcessExecuteList(String& string) {
 
 			uint64 index = ac.Find('!');
 
-			if (index == ~0) continue;
+			if (index == String::npos) continue;
 
 			CreateFolderAndFile(tmp2.str);
 
@@ -404,7 +404,7 @@ void FuckMake::ProcessExecute(String& string) {
 
 		uint64 index = ac.Find('!');
 
-		if (index == ~0) continue;
+		if (index == String::npos) continue;
 
 		CreateFolderAndFile(outdir);
 
@@ -423,7 +423,7 @@ uint64 FuckMake::FindMatchingParenthesis(const String& string, uint64 start) {
 		}
 	}
 
-	return ~0;
+	return String::npos;
 }
 
 Variable* FuckMake::GetVariable(const String& name) {

--- a/FuckMake/src/parsing/parsing.cpp
+++ b/FuckMake/src/parsing/parsing.cpp
@@ -1,6 +1,5 @@
 #include "parsing.h"
 
-#include <Windows.h>
 #include <util/util.h>
 
 FuckMake::FuckMake(const String& filename, const String& target) {
@@ -311,7 +310,7 @@ void FuckMake::ProcessDeleteFiles(String& string) {
 	List<String> files = string.Split(" ");
 
 	for (uint64 i = 0; i < files.GetCount(); i++) {
-		DeleteFile(files[i].str);
+		::remove(files[i].str);
 	}
 }
 

--- a/FuckMake/src/util/dirent.h
+++ b/FuckMake/src/util/dirent.h
@@ -1,0 +1,1251 @@
+/*
+ * Dirent interface for Microsoft Visual Studio
+ *
+ * Copyright (C) 1998-2019 Toni Ronkko
+ * This file is part of dirent.  Dirent may be freely distributed
+ * under the MIT license.  For all details and documentation, see
+ * https://github.com/tronkko/dirent
+ */
+#ifndef DIRENT_H
+#define DIRENT_H
+
+ /* Hide warnings about unreferenced local functions */
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wunused-function"
+#elif defined(_MSC_VER)
+#   pragma warning(disable:4505)
+#elif defined(__GNUC__)
+#   pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
+/*
+ * Include windows.h without Windows Sockets 1.1 to prevent conflicts with
+ * Windows Sockets 2.0.
+ */
+#ifndef WIN32_LEAN_AND_MEAN
+#   define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <wchar.h>
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+ /* Indicates that d_type field is available in dirent structure */
+#define _DIRENT_HAVE_D_TYPE
+
+/* Indicates that d_namlen field is available in dirent structure */
+#define _DIRENT_HAVE_D_NAMLEN
+
+/* Entries missing from MSVC 6.0 */
+#if !defined(FILE_ATTRIBUTE_DEVICE)
+#   define FILE_ATTRIBUTE_DEVICE 0x40
+#endif
+
+/* File type and permission flags for stat(), general mask */
+#if !defined(S_IFMT)
+#   define S_IFMT _S_IFMT
+#endif
+
+/* Directory bit */
+#if !defined(S_IFDIR)
+#   define S_IFDIR _S_IFDIR
+#endif
+
+/* Character device bit */
+#if !defined(S_IFCHR)
+#   define S_IFCHR _S_IFCHR
+#endif
+
+/* Pipe bit */
+#if !defined(S_IFFIFO)
+#   define S_IFFIFO _S_IFFIFO
+#endif
+
+/* Regular file bit */
+#if !defined(S_IFREG)
+#   define S_IFREG _S_IFREG
+#endif
+
+/* Read permission */
+#if !defined(S_IREAD)
+#   define S_IREAD _S_IREAD
+#endif
+
+/* Write permission */
+#if !defined(S_IWRITE)
+#   define S_IWRITE _S_IWRITE
+#endif
+
+/* Execute permission */
+#if !defined(S_IEXEC)
+#   define S_IEXEC _S_IEXEC
+#endif
+
+/* Pipe */
+#if !defined(S_IFIFO)
+#   define S_IFIFO _S_IFIFO
+#endif
+
+/* Block device */
+#if !defined(S_IFBLK)
+#   define S_IFBLK 0
+#endif
+
+/* Link */
+#if !defined(S_IFLNK)
+#   define S_IFLNK 0
+#endif
+
+/* Socket */
+#if !defined(S_IFSOCK)
+#   define S_IFSOCK 0
+#endif
+
+/* Read user permission */
+#if !defined(S_IRUSR)
+#   define S_IRUSR S_IREAD
+#endif
+
+/* Write user permission */
+#if !defined(S_IWUSR)
+#   define S_IWUSR S_IWRITE
+#endif
+
+/* Execute user permission */
+#if !defined(S_IXUSR)
+#   define S_IXUSR 0
+#endif
+
+/* Read group permission */
+#if !defined(S_IRGRP)
+#   define S_IRGRP 0
+#endif
+
+/* Write group permission */
+#if !defined(S_IWGRP)
+#   define S_IWGRP 0
+#endif
+
+/* Execute group permission */
+#if !defined(S_IXGRP)
+#   define S_IXGRP 0
+#endif
+
+/* Read others permission */
+#if !defined(S_IROTH)
+#   define S_IROTH 0
+#endif
+
+/* Write others permission */
+#if !defined(S_IWOTH)
+#   define S_IWOTH 0
+#endif
+
+/* Execute others permission */
+#if !defined(S_IXOTH)
+#   define S_IXOTH 0
+#endif
+
+/* Maximum length of file name */
+#if !defined(PATH_MAX)
+#   define PATH_MAX MAX_PATH
+#endif
+#if !defined(FILENAME_MAX)
+#   define FILENAME_MAX MAX_PATH
+#endif
+#if !defined(NAME_MAX)
+#   define NAME_MAX FILENAME_MAX
+#endif
+
+/* File type flags for d_type */
+#define DT_UNKNOWN 0
+#define DT_REG S_IFREG
+#define DT_DIR S_IFDIR
+#define DT_FIFO S_IFIFO
+#define DT_SOCK S_IFSOCK
+#define DT_CHR S_IFCHR
+#define DT_BLK S_IFBLK
+#define DT_LNK S_IFLNK
+
+/* Macros for converting between st_mode and d_type */
+#define IFTODT(mode) ((mode) & S_IFMT)
+#define DTTOIF(type) (type)
+
+/*
+ * File type macros.  Note that block devices, sockets and links cannot be
+ * distinguished on Windows and the macros S_ISBLK, S_ISSOCK and S_ISLNK are
+ * only defined for compatibility.  These macros should always return false
+ * on Windows.
+ */
+#if !defined(S_ISFIFO)
+#   define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#endif
+#if !defined(S_ISDIR)
+#   define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+#if !defined(S_ISREG)
+#   define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#endif
+#if !defined(S_ISLNK)
+#   define S_ISLNK(mode) (((mode) & S_IFMT) == S_IFLNK)
+#endif
+#if !defined(S_ISSOCK)
+#   define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
+#endif
+#if !defined(S_ISCHR)
+#   define S_ISCHR(mode) (((mode) & S_IFMT) == S_IFCHR)
+#endif
+#if !defined(S_ISBLK)
+#   define S_ISBLK(mode) (((mode) & S_IFMT) == S_IFBLK)
+#endif
+
+ /* Return the exact length of the file name without zero terminator */
+#define _D_EXACT_NAMLEN(p) ((p)->d_namlen)
+
+/* Return the maximum size of a file name */
+#define _D_ALLOC_NAMLEN(p) ((PATH_MAX)+1)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+	/* Wide-character version */
+	struct _wdirent {
+		/* Always zero */
+		long d_ino;
+
+		/* File position within stream */
+		long d_off;
+
+		/* Structure size */
+		unsigned short d_reclen;
+
+		/* Length of name without \0 */
+		size_t d_namlen;
+
+		/* File type */
+		int d_type;
+
+		/* File name */
+		wchar_t d_name[PATH_MAX + 1];
+	};
+	typedef struct _wdirent _wdirent;
+
+	struct _WDIR {
+		/* Current directory entry */
+		struct _wdirent ent;
+
+		/* Private file data */
+		WIN32_FIND_DATAW data;
+
+		/* True if data is valid */
+		int cached;
+
+		/* Win32 search handle */
+		HANDLE handle;
+
+		/* Initial directory name */
+		wchar_t* patt;
+	};
+	typedef struct _WDIR _WDIR;
+
+	/* Multi-byte character version */
+	struct dirent {
+		/* Always zero */
+		long d_ino;
+
+		/* File position within stream */
+		long d_off;
+
+		/* Structure size */
+		unsigned short d_reclen;
+
+		/* Length of name without \0 */
+		size_t d_namlen;
+
+		/* File type */
+		int d_type;
+
+		/* File name */
+		char d_name[PATH_MAX + 1];
+	};
+	typedef struct dirent dirent;
+
+	struct DIR {
+		struct dirent ent;
+		struct _WDIR* wdirp;
+	};
+	typedef struct DIR DIR;
+
+
+	/* Dirent functions */
+	static DIR* opendir(const char* dirname);
+	static _WDIR* _wopendir(const wchar_t* dirname);
+
+	static struct dirent* readdir(DIR* dirp);
+	static struct _wdirent* _wreaddir(_WDIR* dirp);
+
+	static int readdir_r(
+		DIR* dirp, struct dirent* entry, struct dirent** result);
+	static int _wreaddir_r(
+		_WDIR* dirp, struct _wdirent* entry, struct _wdirent** result);
+
+	static int closedir(DIR* dirp);
+	static int _wclosedir(_WDIR* dirp);
+
+	static void rewinddir(DIR* dirp);
+	static void _wrewinddir(_WDIR* dirp);
+
+	static int scandir(const char* dirname, struct dirent*** namelist,
+		int (*filter)(const struct dirent*),
+		int (*compare)(const struct dirent**, const struct dirent**));
+
+	static int alphasort(const struct dirent** a, const struct dirent** b);
+
+	static int versionsort(const struct dirent** a, const struct dirent** b);
+
+
+	/* For compatibility with Symbian */
+#define wdirent _wdirent
+#define WDIR _WDIR
+#define wopendir _wopendir
+#define wreaddir _wreaddir
+#define wclosedir _wclosedir
+#define wrewinddir _wrewinddir
+
+
+/* Internal utility functions */
+	static WIN32_FIND_DATAW* dirent_first(_WDIR* dirp);
+	static WIN32_FIND_DATAW* dirent_next(_WDIR* dirp);
+
+	static int dirent_mbstowcs_s(
+		size_t* pReturnValue,
+		wchar_t* wcstr,
+		size_t sizeInWords,
+		const char* mbstr,
+		size_t count);
+
+	static int dirent_wcstombs_s(
+		size_t* pReturnValue,
+		char* mbstr,
+		size_t sizeInBytes,
+		const wchar_t* wcstr,
+		size_t count);
+
+	static void dirent_set_errno(int error);
+
+
+	/*
+	 * Open directory stream DIRNAME for read and return a pointer to the
+	 * internal working area that is used to retrieve individual directory
+	 * entries.
+	 */
+	static _WDIR*
+		_wopendir(
+			const wchar_t* dirname)
+	{
+		_WDIR* dirp;
+		DWORD n;
+		wchar_t* p;
+
+		/* Must have directory name */
+		if (dirname == NULL || dirname[0] == '\0')
+		{
+			dirent_set_errno(ENOENT);
+			return NULL;
+		}
+
+		/* Allocate new _WDIR structure */
+		dirp = (_WDIR*)malloc(sizeof(struct _WDIR));
+		if (!dirp)
+		{
+			return NULL;
+		}
+
+		/* Reset _WDIR structure */
+		dirp->handle = INVALID_HANDLE_VALUE;
+		dirp->patt = NULL;
+		dirp->cached = 0;
+
+		/*
+		 * Compute the length of full path plus zero terminator
+		 *
+		 * Note that on WinRT there's no way to convert relative paths
+		 * into absolute paths, so just assume it is an absolute path.
+		 */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+		 /* Desktop */
+		n = GetFullPathNameW(dirname, 0, NULL, NULL);
+#else
+		 /* WinRT */
+		n = wcslen(dirname);
+#endif
+
+		/* Allocate room for absolute directory name and search pattern */
+		dirp->patt = (wchar_t*)malloc(sizeof(wchar_t) * n + 16);
+		if (dirp->patt == NULL)
+		{
+			goto exit_closedir;
+		}
+
+		/*
+		 * Convert relative directory name to an absolute one.  This
+		 * allows rewinddir() to function correctly even when current
+		 * working directory is changed between opendir() and rewinddir().
+		 *
+		 * Note that on WinRT there's no way to convert relative paths
+		 * into absolute paths, so just assume it is an absolute path.
+		 */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+		 /* Desktop */
+		n = GetFullPathNameW(dirname, n, dirp->patt, NULL);
+		if (n <= 0)
+		{
+			goto exit_closedir;
+		}
+#else
+		 /* WinRT */
+		wcsncpy_s(dirp->patt, n + 1, dirname, n);
+#endif
+
+		/* Append search pattern \* to the directory name */
+		p = dirp->patt + n;
+		switch (p[-1])
+		{
+		case '\\':
+		case '/':
+		case ':':
+			/* Directory ends in path separator, e.g. c:\temp\ */
+			/*NOP*/;
+			break;
+
+		default:
+			/* Directory name doesn't end in path separator */
+			*p++ = '\\';
+		}
+		*p++ = '*';
+		*p = '\0';
+
+		/* Open directory stream and retrieve the first entry */
+		if (!dirent_first(dirp))
+		{
+			goto exit_closedir;
+		}
+
+		/* Success */
+		return dirp;
+
+		/* Failure */
+	exit_closedir:
+		_wclosedir(dirp);
+		return NULL;
+	}
+
+	/*
+	 * Read next directory entry.
+	 *
+	 * Returns pointer to static directory entry which may be overwritten by
+	 * subsequent calls to _wreaddir().
+	 */
+	static struct _wdirent*
+		_wreaddir(
+			_WDIR* dirp)
+	{
+		struct _wdirent* entry;
+
+		/*
+		 * Read directory entry to buffer.  We can safely ignore the return value
+		 * as entry will be set to NULL in case of error.
+		 */
+		(void)_wreaddir_r(dirp, &dirp->ent, &entry);
+
+		/* Return pointer to statically allocated directory entry */
+		return entry;
+	}
+
+	/*
+	 * Read next directory entry.
+	 *
+	 * Returns zero on success.  If end of directory stream is reached, then sets
+	 * result to NULL and returns zero.
+	 */
+	static int
+		_wreaddir_r(
+			_WDIR* dirp,
+			struct _wdirent* entry,
+			struct _wdirent** result)
+	{
+		WIN32_FIND_DATAW* datap;
+
+		/* Read next directory entry */
+		datap = dirent_next(dirp);
+		if (datap)
+		{
+			size_t n;
+			DWORD attr;
+
+			/*
+			 * Copy file name as wide-character string.  If the file name is too
+			 * long to fit in to the destination buffer, then truncate file name
+			 * to PATH_MAX characters and zero-terminate the buffer.
+			 */
+			n = 0;
+			while (n < PATH_MAX && datap->cFileName[n] != 0)
+			{
+				entry->d_name[n] = datap->cFileName[n];
+				n++;
+			}
+			entry->d_name[n] = 0;
+
+			/* Length of file name excluding zero terminator */
+			entry->d_namlen = n;
+
+			/* File type */
+			attr = datap->dwFileAttributes;
+			if ((attr & FILE_ATTRIBUTE_DEVICE) != 0)
+			{
+				entry->d_type = DT_CHR;
+			}
+			else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0)
+			{
+				entry->d_type = DT_DIR;
+			}
+			else
+			{
+				entry->d_type = DT_REG;
+			}
+
+			/* Reset dummy fields */
+			entry->d_ino = 0;
+			entry->d_off = 0;
+			entry->d_reclen = sizeof(struct _wdirent);
+
+			/* Set result address */
+			*result = entry;
+
+		}
+		else
+		{
+
+			/* Return NULL to indicate end of directory */
+			*result = NULL;
+
+		}
+
+		return /*OK*/0;
+	}
+
+	/*
+	 * Close directory stream opened by opendir() function.  This invalidates the
+	 * DIR structure as well as any directory entry read previously by
+	 * _wreaddir().
+	 */
+	static int
+		_wclosedir(
+			_WDIR* dirp)
+	{
+		int ok;
+		if (dirp)
+		{
+
+			/* Release search handle */
+			if (dirp->handle != INVALID_HANDLE_VALUE)
+			{
+				FindClose(dirp->handle);
+			}
+
+			/* Release search pattern */
+			free(dirp->patt);
+
+			/* Release directory structure */
+			free(dirp);
+			ok = /*success*/0;
+
+		}
+		else
+		{
+
+			/* Invalid directory stream */
+			dirent_set_errno(EBADF);
+			ok = /*failure*/-1;
+
+		}
+		return ok;
+	}
+
+	/*
+	 * Rewind directory stream such that _wreaddir() returns the very first
+	 * file name again.
+	 */
+	static void
+		_wrewinddir(
+			_WDIR* dirp)
+	{
+		if (dirp)
+		{
+			/* Release existing search handle */
+			if (dirp->handle != INVALID_HANDLE_VALUE)
+			{
+				FindClose(dirp->handle);
+			}
+
+			/* Open new search handle */
+			dirent_first(dirp);
+		}
+	}
+
+	/* Get first directory entry (internal) */
+	static WIN32_FIND_DATAW*
+		dirent_first(
+			_WDIR* dirp)
+	{
+		WIN32_FIND_DATAW* datap;
+		DWORD error;
+
+		/* Open directory and retrieve the first entry */
+		dirp->handle = FindFirstFileExW(
+			dirp->patt, FindExInfoStandard, &dirp->data,
+			FindExSearchNameMatch, NULL, 0);
+		if (dirp->handle != INVALID_HANDLE_VALUE)
+		{
+
+			/* a directory entry is now waiting in memory */
+			datap = &dirp->data;
+			dirp->cached = 1;
+
+		}
+		else
+		{
+
+			/* Failed to open directory: no directory entry in memory */
+			dirp->cached = 0;
+			datap = NULL;
+
+			/* Set error code */
+			error = GetLastError();
+			switch (error)
+			{
+			case ERROR_ACCESS_DENIED:
+				/* No read access to directory */
+				dirent_set_errno(EACCES);
+				break;
+
+			case ERROR_DIRECTORY:
+				/* Directory name is invalid */
+				dirent_set_errno(ENOTDIR);
+				break;
+
+			case ERROR_PATH_NOT_FOUND:
+			default:
+				/* Cannot find the file */
+				dirent_set_errno(ENOENT);
+			}
+
+		}
+		return datap;
+	}
+
+	/*
+	 * Get next directory entry (internal).
+	 *
+	 * Returns
+	 */
+	static WIN32_FIND_DATAW*
+		dirent_next(
+			_WDIR* dirp)
+	{
+		WIN32_FIND_DATAW* p;
+
+		/* Get next directory entry */
+		if (dirp->cached != 0)
+		{
+
+			/* A valid directory entry already in memory */
+			p = &dirp->data;
+			dirp->cached = 0;
+
+		}
+		else if (dirp->handle != INVALID_HANDLE_VALUE)
+		{
+
+			/* Get the next directory entry from stream */
+			if (FindNextFileW(dirp->handle, &dirp->data) != FALSE)
+			{
+				/* Got a file */
+				p = &dirp->data;
+			}
+			else
+			{
+				/* The very last entry has been processed or an error occurred */
+				FindClose(dirp->handle);
+				dirp->handle = INVALID_HANDLE_VALUE;
+				p = NULL;
+			}
+
+		}
+		else
+		{
+
+			/* End of directory stream reached */
+			p = NULL;
+
+		}
+
+		return p;
+	}
+
+	/*
+	 * Open directory stream using plain old C-string.
+	 */
+	static DIR*
+		opendir(
+			const char* dirname)
+	{
+		struct DIR* dirp;
+
+		/* Must have directory name */
+		if (dirname == NULL || dirname[0] == '\0')
+		{
+			dirent_set_errno(ENOENT);
+			return NULL;
+		}
+
+		/* Allocate memory for DIR structure */
+		dirp = (DIR*)malloc(sizeof(struct DIR));
+		if (!dirp)
+		{
+			return NULL;
+		}
+		{
+			int error;
+			wchar_t wname[PATH_MAX + 1];
+			size_t n;
+
+			/* Convert directory name to wide-character string */
+			error = dirent_mbstowcs_s(
+				&n, wname, PATH_MAX + 1, dirname, PATH_MAX + 1);
+			if (error)
+			{
+				/*
+				 * Cannot convert file name to wide-character string.  This
+				 * occurs if the string contains invalid multi-byte sequences or
+				 * the output buffer is too small to contain the resulting
+				 * string.
+				 */
+				goto exit_free;
+			}
+
+
+			/* Open directory stream using wide-character name */
+			dirp->wdirp = _wopendir(wname);
+			if (!dirp->wdirp)
+			{
+				goto exit_free;
+			}
+
+		}
+
+		/* Success */
+		return dirp;
+
+		/* Failure */
+	exit_free:
+		free(dirp);
+		return NULL;
+	}
+
+	/*
+	 * Read next directory entry.
+	 */
+	static struct dirent*
+		readdir(
+			DIR* dirp)
+	{
+		struct dirent* entry;
+
+		/*
+		 * Read directory entry to buffer.  We can safely ignore the return value
+		 * as entry will be set to NULL in case of error.
+		 */
+		(void)readdir_r(dirp, &dirp->ent, &entry);
+
+		/* Return pointer to statically allocated directory entry */
+		return entry;
+	}
+
+	/*
+	 * Read next directory entry into called-allocated buffer.
+	 *
+	 * Returns zero on success.  If the end of directory stream is reached, then
+	 * sets result to NULL and returns zero.
+	 */
+	static int
+		readdir_r(
+			DIR* dirp,
+			struct dirent* entry,
+			struct dirent** result)
+	{
+		WIN32_FIND_DATAW* datap;
+
+		/* Read next directory entry */
+		datap = dirent_next(dirp->wdirp);
+		if (datap)
+		{
+			size_t n;
+			int error;
+
+			/* Attempt to convert file name to multi-byte string */
+			error = dirent_wcstombs_s(
+				&n, entry->d_name, PATH_MAX + 1, datap->cFileName, PATH_MAX + 1);
+
+			/*
+			 * If the file name cannot be represented by a multi-byte string,
+			 * then attempt to use old 8+3 file name.  This allows traditional
+			 * Unix-code to access some file names despite of unicode
+			 * characters, although file names may seem unfamiliar to the user.
+			 *
+			 * Be ware that the code below cannot come up with a short file
+			 * name unless the file system provides one.  At least
+			 * VirtualBox shared folders fail to do this.
+			 */
+			if (error && datap->cAlternateFileName[0] != '\0')
+			{
+				error = dirent_wcstombs_s(
+					&n, entry->d_name, PATH_MAX + 1,
+					datap->cAlternateFileName, PATH_MAX + 1);
+			}
+
+			if (!error)
+			{
+				DWORD attr;
+
+				/* Length of file name excluding zero terminator */
+				entry->d_namlen = n - 1;
+
+				/* File attributes */
+				attr = datap->dwFileAttributes;
+				if ((attr & FILE_ATTRIBUTE_DEVICE) != 0)
+				{
+					entry->d_type = DT_CHR;
+				}
+				else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0)
+				{
+					entry->d_type = DT_DIR;
+				}
+				else
+				{
+					entry->d_type = DT_REG;
+				}
+
+				/* Reset dummy fields */
+				entry->d_ino = 0;
+				entry->d_off = 0;
+				entry->d_reclen = sizeof(struct dirent);
+
+			}
+			else
+			{
+
+				/*
+				 * Cannot convert file name to multi-byte string so construct
+				 * an erroneous directory entry and return that.  Note that
+				 * we cannot return NULL as that would stop the processing
+				 * of directory entries completely.
+				 */
+				entry->d_name[0] = '?';
+				entry->d_name[1] = '\0';
+				entry->d_namlen = 1;
+				entry->d_type = DT_UNKNOWN;
+				entry->d_ino = 0;
+				entry->d_off = -1;
+				entry->d_reclen = 0;
+
+			}
+
+			/* Return pointer to directory entry */
+			*result = entry;
+
+		}
+		else
+		{
+
+			/* No more directory entries */
+			*result = NULL;
+
+		}
+
+		return /*OK*/0;
+	}
+
+	/*
+	 * Close directory stream.
+	 */
+	static int
+		closedir(
+			DIR * dirp)
+	{
+		int ok;
+		if (dirp)
+		{
+
+			/* Close wide-character directory stream */
+			ok = _wclosedir(dirp->wdirp);
+			dirp->wdirp = NULL;
+
+			/* Release multi-byte character version */
+			free(dirp);
+
+		}
+		else
+		{
+
+			/* Invalid directory stream */
+			dirent_set_errno(EBADF);
+			ok = /*failure*/-1;
+
+		}
+		return ok;
+	}
+
+	/*
+	 * Rewind directory stream to beginning.
+	 */
+	static void
+		rewinddir(
+			DIR * dirp)
+	{
+		/* Rewind wide-character string directory stream */
+		_wrewinddir(dirp->wdirp);
+	}
+
+	/*
+	 * Scan directory for entries.
+	 */
+	static int
+		scandir(
+			const char* dirname,
+			struct dirent*** namelist,
+			int (*filter)(const struct dirent*),
+			int (*compare)(const struct dirent**, const struct dirent**))
+	{
+		struct dirent** files = NULL;
+		size_t size = 0;
+		size_t allocated = 0;
+		const size_t init_size = 1;
+		DIR* dir = NULL;
+		struct dirent* entry;
+		struct dirent* tmp = NULL;
+		size_t i;
+		int result = 0;
+
+		/* Open directory stream */
+		dir = opendir(dirname);
+		if (dir)
+		{
+
+			/* Read directory entries to memory */
+			while (1)
+			{
+
+				/* Enlarge pointer table to make room for another pointer */
+				if (size >= allocated)
+				{
+					void* p;
+					size_t num_entries;
+
+					/* Compute number of entries in the enlarged pointer table */
+					if (size < init_size)
+					{
+						/* Allocate initial pointer table */
+						num_entries = init_size;
+					}
+					else
+					{
+						/* Double the size */
+						num_entries = size * 2;
+					}
+
+					/* Allocate first pointer table or enlarge existing table */
+					p = realloc(files, sizeof(void*) * num_entries);
+					if (p != NULL)
+					{
+						/* Got the memory */
+						files = (dirent * *)p;
+						allocated = num_entries;
+					}
+					else
+					{
+						/* Out of memory */
+						result = -1;
+						break;
+					}
+
+				}
+
+				/* Allocate room for temporary directory entry */
+				if (tmp == NULL)
+				{
+					tmp = (struct dirent*) malloc(sizeof(struct dirent));
+					if (tmp == NULL)
+					{
+						/* Cannot allocate temporary directory entry */
+						result = -1;
+						break;
+					}
+				}
+
+				/* Read directory entry to temporary area */
+				if (readdir_r(dir, tmp, &entry) == /*OK*/0)
+				{
+
+					/* Did we get an entry? */
+					if (entry != NULL)
+					{
+						int pass;
+
+						/* Determine whether to include the entry in result */
+						if (filter)
+						{
+							/* Let the filter function decide */
+							pass = filter(tmp);
+						}
+						else
+						{
+							/* No filter function, include everything */
+							pass = 1;
+						}
+
+						if (pass)
+						{
+							/* Store the temporary entry to pointer table */
+							files[size++] = tmp;
+							tmp = NULL;
+
+							/* Keep up with the number of files */
+							result++;
+						}
+
+					}
+					else
+					{
+
+						/*
+						 * End of directory stream reached => sort entries and
+						 * exit.
+						 */
+						qsort(files, size, sizeof(void*),
+							(int (*) (const void*, const void*)) compare);
+						break;
+
+					}
+
+				}
+				else
+				{
+					/* Error reading directory entry */
+					result = /*Error*/ -1;
+					break;
+				}
+
+			}
+
+		}
+		else
+		{
+			/* Cannot open directory */
+			result = /*Error*/ -1;
+		}
+
+		/* Release temporary directory entry */
+		free(tmp);
+
+		/* Release allocated memory on error */
+		if (result < 0)
+		{
+			for (i = 0; i < size; i++)
+			{
+				free(files[i]);
+			}
+			free(files);
+			files = NULL;
+		}
+
+		/* Close directory stream */
+		if (dir)
+		{
+			closedir(dir);
+		}
+
+		/* Pass pointer table to caller */
+		if (namelist)
+		{
+			*namelist = files;
+		}
+		return result;
+	}
+
+	/* Alphabetical sorting */
+	static int
+		alphasort(
+			const struct dirent** a, const struct dirent** b)
+	{
+		return strcoll((*a)->d_name, (*b)->d_name);
+	}
+
+	/* Sort versions */
+	static int
+		versionsort(
+			const struct dirent** a, const struct dirent** b)
+	{
+		/* FIXME: implement strverscmp and use that */
+		return alphasort(a, b);
+	}
+
+	/* Convert multi-byte string to wide character string */
+	static int
+		dirent_mbstowcs_s(
+			size_t * pReturnValue,
+			wchar_t* wcstr,
+			size_t sizeInWords,
+			const char* mbstr,
+			size_t count)
+	{
+		int error;
+
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+		/* Microsoft Visual Studio 2005 or later */
+		error = mbstowcs_s(pReturnValue, wcstr, sizeInWords, mbstr, count);
+
+#else
+
+		/* Older Visual Studio or non-Microsoft compiler */
+		size_t n;
+
+		/* Convert to wide-character string (or count characters) */
+		n = mbstowcs(wcstr, mbstr, sizeInWords);
+		if (!wcstr || n < count)
+		{
+
+			/* Zero-terminate output buffer */
+			if (wcstr && sizeInWords)
+			{
+				if (n >= sizeInWords)
+				{
+					n = sizeInWords - 1;
+				}
+				wcstr[n] = 0;
+			}
+
+			/* Length of resulting multi-byte string WITH zero terminator */
+			if (pReturnValue)
+			{
+				*pReturnValue = n + 1;
+			}
+
+			/* Success */
+			error = 0;
+
+		}
+		else
+		{
+
+			/* Could not convert string */
+			error = 1;
+
+		}
+
+#endif
+		return error;
+	}
+
+	/* Convert wide-character string to multi-byte string */
+	static int
+		dirent_wcstombs_s(
+			size_t * pReturnValue,
+			char* mbstr,
+			size_t sizeInBytes, /* max size of mbstr */
+			const wchar_t* wcstr,
+			size_t count)
+	{
+		int error;
+
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+		/* Microsoft Visual Studio 2005 or later */
+		error = wcstombs_s(pReturnValue, mbstr, sizeInBytes, wcstr, count);
+
+#else
+
+		/* Older Visual Studio or non-Microsoft compiler */
+		size_t n;
+
+		/* Convert to multi-byte string (or count the number of bytes needed) */
+		n = wcstombs(mbstr, wcstr, sizeInBytes);
+		if (!mbstr || n < count)
+		{
+
+			/* Zero-terminate output buffer */
+			if (mbstr && sizeInBytes)
+			{
+				if (n >= sizeInBytes)
+				{
+					n = sizeInBytes - 1;
+				}
+				mbstr[n] = '\0';
+			}
+
+			/* Length of resulting multi-bytes string WITH zero-terminator */
+			if (pReturnValue)
+			{
+				*pReturnValue = n + 1;
+			}
+
+			/* Success */
+			error = 0;
+
+		}
+		else
+		{
+
+			/* Cannot convert string */
+			error = 1;
+
+		}
+
+#endif
+		return error;
+	}
+
+	/* Set errno variable */
+	static void
+		dirent_set_errno(
+			int error)
+	{
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+		/* Microsoft Visual Studio 2005 and later */
+		_set_errno(error);
+
+#else
+
+		/* Non-Microsoft compiler or older Microsoft compiler */
+		errno = error;
+
+#endif
+	}
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /*DIRENT_H*/

--- a/FuckMake/src/util/list.h
+++ b/FuckMake/src/util/list.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <core/core.h>
 
 #define FM_PREALLOC_COUNT 128

--- a/FuckMake/src/util/list.h
+++ b/FuckMake/src/util/list.h
@@ -352,7 +352,7 @@ public:
 			if (items[i] == item) return i;
 		}
 
-		return ~0;
+		return (uint64)~0;
 	}
 
 	template<typename K>
@@ -362,7 +362,7 @@ public:
 			if (CmpFunc(items[i], item)) return i;
 		}
 
-		return ~0;
+		return (uint64)~0;
 	}
 
 	inline T& operator[](uint64 index) {

--- a/FuckMake/src/util/string.cpp
+++ b/FuckMake/src/util/string.cpp
@@ -139,9 +139,9 @@ String& String::RemoveWhitespace(bool only) {
 
 		index = String::npos;
 
-		for (int64 i = length-1; i >= (int64)length; i--) {
+		for (int64 i = (int64)length-1; i >= (int64)length; i--) {
 			if (str[i] != ' ' && str[i] != '\n' && str[i] != '\r' && str[i] != '\t') {
-				index = i + 1;
+				index = (uint64)i + 1;
 				break;
 			}
 		}
@@ -178,17 +178,17 @@ uint64 String::Find(const char* const string, uint64 offset) const {
 	ASSERT(string != nullptr);
 	uint64 len = strlen(string);
 
-	for (int64 i = offset; i < int64(length - (len - 1)); i++) {
+	for (int64 i = (int64)offset; i < int64(length - (len - 1)); i++) {
 		bool match = true;
 		for (uint64 j = 0; j < len; j++) {
-			if (str[i + j] != string[j]) {
+			if (str[(uint64)i + j] != string[j]) {
 				match = false;
 				break;
 			}
 		}
 
 		if (match) {
-			return i;
+			return (uint64)i;
 		}
 	}
 
@@ -262,7 +262,7 @@ uint64 String::FindReversed(const char character, uint64 offset) const {
 }
 
 uint64 String::FindReversedOr(const char* characters, uint64 offset) const {
-	int64 highest = String::npos;
+	int64 highest = (int64)~0;
 	uint64 len = strlen(characters);
 
 	for (uint64 i = 0; i < len; i++) {
@@ -270,10 +270,10 @@ uint64 String::FindReversedOr(const char* characters, uint64 offset) const {
 
 		if (index == String::npos) continue;
 
-		highest = (int64)index > highest ? index : highest;
+		highest = (int64)index > highest ? (int64)index : highest;
 	}
 
-	return highest;
+	return (uint64)highest;
 }
 
 bool String::StartsWith(const String& string) const {

--- a/FuckMake/src/util/string.cpp
+++ b/FuckMake/src/util/string.cpp
@@ -1,6 +1,8 @@
 #include "string.h"
 #include "util.h"
 
+const uint64 String::npos = (uint64)~0;
+
 String::String() : str(nullptr), length(0) { }
 
 String::String(const char* const string) {
@@ -119,22 +121,22 @@ String& String::RemoveWhitespace(bool only) {
 		const char* list = "\n\r\t ";
 		for (uint64 i = 0; i < 4; i++) {
 			index = 0;
-			while ((index = Find(list[i], index)) != ~0) {
+			while ((index = Find(list[i], index)) != String::npos) {
 				Remove(index, index);
 			}
 		}
 	} else {
-		uint64 index = ~0;
+		uint64 index = String::npos;
 		for (uint64 i = 0; i < length; i++) {
 			if (str[i] != ' ' && str[i] != '\n' && str[i] != '\r' && str[i] != '\t') {
 				index = i-1;
 				break;
 			}
 		}
-		
-		if (index != ~0) Remove(0, index);
 
-		index = ~0;
+		if (index != String::npos) Remove(0, index);
+
+		index = String::npos;
 
 		for (int64 i = length-1; i >= (int64)length; i--) {
 			if (str[i] != ' ' && str[i] != '\n' && str[i] != '\r' && str[i] != '\t') {
@@ -159,7 +161,7 @@ uint64 String::Count(const char* const string, uint64 offset, uint64 end) const 
 	uint64 index = offset - 1;
 	uint64 count = 0;
 
-	while ((index = Find(string, index + 1)) != ~0) {
+	while ((index = Find(string, index + 1)) != String::npos) {
 		if (index > end) break;
 		count++;
 	}
@@ -189,7 +191,7 @@ uint64 String::Find(const char* const string, uint64 offset) const {
 		}
 	}
 
-	return ~0;
+	return String::npos;
 }
 
 uint64 String::Find(const char character, uint64 offset) const {
@@ -197,11 +199,11 @@ uint64 String::Find(const char character, uint64 offset) const {
 		if (str[i] == character) return i;
 	}
 
-	return ~0;
+	return String::npos;
 }
 
 uint64 String::FindOr(const char* characters, uint64 offset) const {
-	uint64 lowest = ~0;
+	uint64 lowest = String::npos;
 	uint64 len = strlen(characters);
 
 	for (uint64 i = 0; i < len; i++) {
@@ -241,7 +243,7 @@ uint64 String::FindReversed(const char* const string, uint64 offset) const {
 		}
 	}
 
-	return ~0;
+	return String::npos;
 }
 
 uint64 String::FindReversed(const char character, uint64 offset) const {
@@ -255,17 +257,17 @@ uint64 String::FindReversed(const char character, uint64 offset) const {
 		if (str[i] == character) return i;
 	}
 
-	return ~0;
+	return String::npos;
 }
 
 uint64 String::FindReversedOr(const char* characters, uint64 offset) const {
-	int64 highest = ~0;
+	int64 highest = String::npos;
 	uint64 len = strlen(characters);
 
 	for (uint64 i = 0; i < len; i++) {
 		uint64 index = FindReversed(characters[i], offset);
 
-		if (index == ~0) continue;
+		if (index == String::npos) continue;
 
 		highest = (int64)index > highest ? index : highest;
 	}
@@ -310,7 +312,7 @@ bool String::EndsWith(const char* const string) const {
 }
 
 String String::SubString(uint64 start, uint64 end) const {
-	ASSERT(start != ~0 && end != ~0);
+	ASSERT(start != String::npos && end != String::npos);
 	ASSERT(end >= start);
 
 	uint64 len = end - start + 1;
@@ -329,8 +331,8 @@ String String::SubString(const char* const start, const char* const end) const {
 	return SubString(Find(start), Find(end));
 }
 
-List<String> String::Split(const String& delimiters, bool includeEmtyLines) const {
-	return Split(delimiters.str);
+List<String> String::Split(const String& delimiters, bool includeEmptyLines) const {
+	return Split(delimiters.str, includeEmptyLines);
 }
 
 void String::Insert(uint64 start, uint64 end, const String& string) {
@@ -357,7 +359,7 @@ void String::Insert(uint64 start, uint64 end, const char* const string) {
 	delete[] tmp;
 }
 
-List<String> String::Split(const char* const delimiters, bool includeEmtyLines) const {
+List<String> String::Split(const char* const delimiters, bool includeEmptyLines) const {
 	List<String> list;
 
 	uint64 numDelimiters = strlen(delimiters);
@@ -368,7 +370,7 @@ List<String> String::Split(const char* const delimiters, bool includeEmtyLines) 
 		for (uint64 j = 0; j < numDelimiters; j++) {
 			if (str[i] == delimiters[j]) {
 				if (lastIndex == i - 1 || lastIndex == i) {
-					if (includeEmtyLines) {
+					if (includeEmptyLines) {
 						list.Add(String(""));
 						lastIndex++;
 					}

--- a/FuckMake/src/util/string.cpp
+++ b/FuckMake/src/util/string.cpp
@@ -1,5 +1,6 @@
 #include "string.h"
 #include "util.h"
+#include <memory.h>
 
 const uint64 String::npos = (uint64)~0;
 

--- a/FuckMake/src/util/string.h
+++ b/FuckMake/src/util/string.h
@@ -35,8 +35,8 @@ public:
 	String& RemoveWhitespace(bool onlyStartAndEnd = false);
 
 	//Counts how many strings is in the string
-	uint64 Count(const String& string, uint64 offset = 0, uint64 end = ~0) const;
-	uint64 Count(const char* const string, uint64 offset = 0, uint64 end = ~0) const;
+	uint64 Count(const String& string, uint64 offset = 0, uint64 end = String::npos) const;
+	uint64 Count(const char* const string, uint64 offset = 0, uint64 end = String::npos) const;
 
 	//Finds the index of the string, if it exist
 	uint64 Find(const String& string, uint64 offset = 0) const;

--- a/FuckMake/src/util/string.h
+++ b/FuckMake/src/util/string.h
@@ -9,6 +9,8 @@ public:
 
 	uint64 length;
 
+	static const uint64 npos;
+
 public:
 	String();
 	String(const char* const string);
@@ -66,8 +68,8 @@ public:
 	void Insert(uint64 start, uint64 end, const String& string);
 	void Insert(uint64 start, uint64 end, const char* const string);
 
-	List<String> Split(const String& delimiters, bool includeEmtyLines = false) const;
-	List<String> Split(const char* const delimiters, bool includeEmtyLines = false) const;
+	List<String> Split(const String& delimiters, bool includeEmptyLines = false) const;
+	List<String> Split(const char* const delimiters, bool includeEmptyLines = false) const;
 
 	char& operator[](uint64 index);
 	char operator[](uint64 index) const;

--- a/FuckMake/src/util/util.cpp
+++ b/FuckMake/src/util/util.cpp
@@ -46,7 +46,7 @@ void CreateFolderAndFile(const String& filename) {
 	if (filename.Count("/") != 0) {
 		List<String> folders = filename.Split("/");
 
-		String path = "";
+		String path("");
 
 		for (uint64 i = 0; i < folders.GetCount() - 1; i++) {
 			CreateDirectory(path.Append(folders[i] + "/"));
@@ -60,19 +60,19 @@ void CreateFolderAndFile(const String& filename) {
 List<FileInfo> ScanDirectory(const String& directory) {
 	List<FileInfo> ret;
 
-	DIR *dir;
-	struct dirent *ent;
-	if((dir = opendir(directory.str)) != NULL) {
-		/* print all the files and directories within directory */
-		while ((ent = readdir(dir)) != NULL) {
-			bool skip = ent->d_name[0] == '.' && (ent->d_name[1] == '\0' || ent->d_name[1] == '.'); // skip directory . & ..
-			if(ent->d_type == DT_DIR && !skip) ret.Add(ScanDirectory(directory + ent->d_name + "/"));
-			if(ent->d_type == DT_REG) ret.Add({ directory + ent->d_name });
-		}
+	DIR *dir = opendir(directory.str);
+	if (dir == NULL) return ret;
 
-		closedir(dir);
+	struct dirent *ent;
+	while ((ent = readdir(dir)) != NULL) {
+		String filename = ent->d_name;
+
+		if (filename == "." || filename == "..") continue; // skip directory . & ..
+		if (ent->d_type == DT_DIR) ret.Add(ScanDirectory(directory + filename + "/"));
+		if (ent->d_type == DT_REG) ret.Add({ directory + filename });
 	}
 
+	closedir(dir);
 	return ret;
 }
 
@@ -87,9 +87,9 @@ List<FileInfo> ScanDirectory(const String& directory) {
 void SetColor(WORD color) {
 	static WORD defaultAttributes = 0;
 
-	if(!defaultAttributes) {
+	if (!defaultAttributes) {
 		CONSOLE_SCREEN_BUFFER_INFO info;
-		if(!GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info)) return;
+		if (!GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info)) return;
 		defaultAttributes = info.wAttributes;
 	}
 

--- a/FuckMake/src/util/util.cpp
+++ b/FuckMake/src/util/util.cpp
@@ -46,11 +46,9 @@ void CreateFolderAndFile(const String& filename) {
 	if (filename.Count("/") != 0) {
 		List<String> folders = filename.Split("/");
 
-		String path = folders[0] + "/";
+		String path = "";
 
-		CreateDirectory(path);
-
-		for (uint64 i = 1; i < folders.GetCount() - 1; i++) {
+		for (uint64 i = 0; i < folders.GetCount() - 1; i++) {
 			CreateDirectory(path.Append(folders[i] + "/"));
 		}
 	}

--- a/FuckMake/src/util/util.cpp
+++ b/FuckMake/src/util/util.cpp
@@ -36,14 +36,11 @@ uint8 WriteFile(const String& filename, const void* data, uint64 size) {
 	return 1;
 }
 
-inline int CreateDirectory(const String& path)
-{
 #ifdef _WIN32
-	return _mkdir(p.c_str());
+	#define CreateDirectory(dir) _mkdir(dir.str);
 #else
-	return mkdir(path.str, 0755);
+	#define CreateDirectory(dir) mkdir(dir.str, 0755);
 #endif
-}
 
 void CreateFolderAndFile(const String& filename) {
 	if (filename.Count("/") != 0) {
@@ -51,10 +48,10 @@ void CreateFolderAndFile(const String& filename) {
 
 		String path = folders[0] + "/";
 
-		CreateDirectory(path.str);
+		CreateDirectory(path);
 
 		for (uint64 i = 1; i < folders.GetCount() - 1; i++) {
-			CreateDirectory((path.Append(folders[i] + "/")).str);
+			CreateDirectory(path.Append(folders[i] + "/"));
 		}
 	}
 
@@ -71,7 +68,7 @@ List<FileInfo> ScanDirectory(const String& directory) {
 		/* print all the files and directories within directory */
 		while ((ent = readdir(dir)) != NULL) {
 			bool skip = ent->d_name[0] == '.' && (ent->d_name[1] == '\0' || ent->d_name[1] == '.'); // skip directory . & ..
-			if(ent->d_type == DT_DIR && !skip) ret.Add(ScanDirectory(String(directory + ent->d_name) + "/"));
+			if(ent->d_type == DT_DIR && !skip) ret.Add(ScanDirectory(directory + ent->d_name + "/"));
 			if(ent->d_type == DT_REG) ret.Add({ directory + ent->d_name });
 		}
 
@@ -135,9 +132,3 @@ void Log(LogLevel level, const char* message, ...) {
 
 	SetColor(COLOR_RESET);
 }
-
-#undef COLOR_INFO
-#undef COLOR_DEBUG
-#undef COLOR_WARNING
-#undef COLOR_ERROR
-#undef COLOR_RESET

--- a/FuckMake/src/util/util.cpp
+++ b/FuckMake/src/util/util.cpp
@@ -1,7 +1,6 @@
 #include "util.h"
 #include <stdarg.h>
 #include <sys/stat.h>
-#include <dirent.h>
 
 uint8* ReadFile(const String& filename, uint64* size) {
 	ASSERT(size != 0);
@@ -37,9 +36,10 @@ uint8 WriteFile(const String& filename, const void* data, uint64 size) {
 }
 
 #ifdef _WIN32
-	#define CreateDirectory(dir) _mkdir(dir.str);
+	#include "dirent.h"
 #else
-	#define CreateDirectory(dir) mkdir(dir.str, 0755);
+	#include <dirent.h>
+	#define CreateDirectory(dir, opts) mkdir(dir, 0755);
 #endif
 
 void CreateFolderAndFile(const String& filename) {
@@ -49,7 +49,7 @@ void CreateFolderAndFile(const String& filename) {
 		String path("");
 
 		for (uint64 i = 0; i < folders.GetCount() - 1; i++) {
-			CreateDirectory(path.Append(folders[i] + "/"));
+			(void)CreateDirectory(path.Append(folders[i] + "/").str, 0);
 		}
 	}
 

--- a/FuckMake/src/util/util.cpp
+++ b/FuckMake/src/util/util.cpp
@@ -6,7 +6,7 @@ uint8* ReadFile(const String& filename, uint64* size) {
 	ASSERT(size != 0);
 
 	struct stat info;
-	*size = stat(filename.str, &info) < 0 ? 0 : info.st_size;
+	*size = stat(filename.str, &info) < 0 ? 0 : (uint64)info.st_size;
 
 	uint8* data = new uint8[*size];
 

--- a/FuckMake/src/util/util.h
+++ b/FuckMake/src/util/util.h
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include "string.h"
 
-#define CLAMP(x, min, max) (x > max ? max : x < min ? min : x)
+#define CLAMP(x, min, max) (x > max ? max : (x < min ? min : x))
 
 uint8* ReadFile(const String& filename, uint64* size);
 uint8  WriteFile(const String& filename, const void* data, uint64 size);


### PR DESCRIPTION
Hi!

I've changed a bunch of things. Here is a full list:
- Deleted Windows-only functions and replaced with cross-platform code
- Added `dirent.h` header file. This library is readily available in Linux/macOS, but not on Windows. This header provides all the functionality available on Linux/macOS to Windows
- Fixed tons of warnings, including implicit conversion warnings, different sign compare and unused parameters
- Fixed missing parameter on cascading `String::Split()` call
- `ScanDirectory()` is now much shorter, easier to understand and faster
- `CreateFolderAndFile()` is now also much shorter and efficient (less temporary strings created)
- Added missing `<utility>` include in `list.h`
- Added missing `<memory>` include in `string.h`
- Removed unnecessary `<memory>` include in `util.cpp`
- Added static member constant `String::npos` that represents the "not found" index. It is equivalent to `~0`, but removes all those "magic values" from the code
- Replaced all `~0` from `String` with `String::npos`
- Fixed *typo* in member function `String::Split()`: `includeEmtyLines` -> `includeEmptyLines`
- Tested on all major OS (Windows/Linux/macOS)

I haven't added any new functionality. All works just like before, but in all major operating systems :)
Any changes or suggestions?